### PR TITLE
Refactor the LCS1 function to call LCS from lcs.go

### DIFF
--- a/lcs_test.go
+++ b/lcs_test.go
@@ -31,44 +31,9 @@ func generateString(length int) string {
 func LCS1(a, b string) (int, string) {
 	arunes := []rune(a)
 	brunes := []rune(b)
-	aLen := len(arunes)
-	bLen := len(brunes)
-	lengths := make([][]int, aLen+1)
-	for i := 0; i <= aLen; i++ {
-		lengths[i] = make([]int, bLen+1)
-	}
+	len, substring := LCS(arunes, brunes)
 
-	// row 0 and column 0 are initialized to 0 already
-	for i := 0; i < aLen; i++ {
-		for j := 0; j < bLen; j++ {
-			if arunes[i] == brunes[j] {
-				lengths[i+1][j+1] = lengths[i][j] + 1
-			} else if lengths[i+1][j] > lengths[i][j+1] {
-				lengths[i+1][j+1] = lengths[i+1][j]
-			} else {
-				lengths[i+1][j+1] = lengths[i][j+1]
-			}
-		}
-	}
-
-	// read the substring out from the matrix
-	s := make([]rune, 0, lengths[aLen][bLen])
-	for x, y := aLen, bLen; x != 0 && y != 0; {
-		if lengths[x][y] == lengths[x-1][y] {
-			x--
-		} else if lengths[x][y] == lengths[x][y-1] {
-			y--
-		} else {
-			s = append(s, arunes[x-1])
-			x--
-			y--
-		}
-	}
-	// reverse string
-	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
-		s[i], s[j] = s[j], s[i]
-	}
-	return len(s), string(s)
+	return len, string(substring)
 }
 
 func Max(more ...int) int {


### PR DESCRIPTION
Previously, the benchmarks were run against a copy of the selected implementation of the longest common subsequence. Now, the benchmarks will run against the actual implementation living in `lcs.go`.